### PR TITLE
[OPS-18376] Migrate CI/CD deploy tasks to private AKS via ARM service connection

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -76,15 +76,22 @@ stages:
     displayName: Deploy
     pool:
       vmImage: $(vmImageName)
-    environment: 'development.default'
+    environment: 'development'
+    variables:
+      k8sCluster: hub-development
     strategy:
       runOnce:
         deploy:
           steps:
-            - task: KubernetesManifest@0
+            - task: KubernetesManifest@1
               displayName: Deploy to Kubernetes cluster
               inputs:
                 action: deploy
+                connectionType: azureResourceManager
+                azureSubscriptionConnection: azure-nonprod
+                azureResourceGroup: HubNonProd
+                kubernetesCluster: $(k8sCluster)
+                namespace: default
                 manifests: |
                   $(Pipeline.Workspace)/deployment/development/superset-deployment.yaml
                 containers: |
@@ -100,15 +107,22 @@ stages:
     displayName: Deploy
     pool:
       vmImage: $(vmImageName)
-    environment: 'staging.default'
+    environment: 'staging'
+    variables:
+      k8sCluster: hub-staging
     strategy:
       runOnce:
         deploy:
           steps:
-            - task: KubernetesManifest@0
+            - task: KubernetesManifest@1
               displayName: Deploy to Kubernetes cluster
               inputs:
                 action: deploy
+                connectionType: azureResourceManager
+                azureSubscriptionConnection: azure-nonprod
+                azureResourceGroup: HubNonProd
+                kubernetesCluster: $(k8sCluster)
+                namespace: default
                 manifests: |
                   $(Pipeline.Workspace)/deployment/staging/superset-deployment.yaml
                 containers: |
@@ -124,15 +138,22 @@ stages:
     displayName: Deploy
     pool:
       vmImage: $(vmImageName)
-    environment: 'production.default'
+    environment: 'production'
+    variables:
+      k8sCluster: hub-prod
     strategy:
       runOnce:
         deploy:
           steps:
-            - task: KubernetesManifest@0
+            - task: KubernetesManifest@1
               displayName: Deploy to Kubernetes cluster
               inputs:
                 action: deploy
+                connectionType: azureResourceManager
+                azureSubscriptionConnection: azure-nonprod
+                azureResourceGroup: HubNonProd
+                kubernetesCluster: $(k8sCluster)
+                namespace: default
                 manifests: |
                   $(Pipeline.Workspace)/deployment/production/superset-deployment.yaml
                 containers: |


### PR DESCRIPTION
## Summary
- Migrate Kubernetes deployment tasks in `azure-pipelines.yml` to use the Azure Resource Manager service connection (`azure-nonprod`) instead of Kubernetes service connections, enabling deployments to the new private AKS clusters via the VNet-peered self-hosted agent
- Drop `.default` namespace suffix from `environment:` references (environments no longer have Kubernetes resources attached — approval gates are preserved)
- Add a `k8sCluster` variable per stage to route each deployment to the correct private cluster (`hub-development`, `hub-staging`, `hub-prod`)

Mirrors the same migration already done for mono-operations: https://github.com/shipmnts/mono-operations/pull/808

## Changes
| Stage | Changes |
|---|---|
| Development | `KubernetesManifest@0→@1`, `k8sCluster: hub-development`, `environment: development` |
| Staging | `KubernetesManifest@0→@1`, `k8sCluster: hub-staging`, `environment: staging` |
| Production | `KubernetesManifest@0→@1`, `k8sCluster: hub-prod`, `environment: production` |

## Test plan
- [ ] Trigger pipeline on `staging` branch and confirm `KubernetesManifest@1` task succeeds
- [ ] Confirm deployment appears in the `staging` environment history in Azure DevOps
- [ ] Verify `hub-staging` pods are running: `az aks command invoke --resource-group HubNonProd --name hub-staging --command "kubectl get pods -n default"`

🤖 Generated with [Claude Code](https://claude.com/claude-code)