### PR TITLE
[OPS-18376] Fix AKS deploy: use azure-arm service connection

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -88,7 +88,7 @@ stages:
               inputs:
                 action: deploy
                 connectionType: azureResourceManager
-                azureSubscriptionConnection: azure-nonprod
+                azureSubscriptionConnection: azure-arm
                 azureResourceGroup: HubNonProd
                 kubernetesCluster: $(k8sCluster)
                 namespace: default
@@ -119,7 +119,7 @@ stages:
               inputs:
                 action: deploy
                 connectionType: azureResourceManager
-                azureSubscriptionConnection: azure-nonprod
+                azureSubscriptionConnection: azure-arm
                 azureResourceGroup: HubNonProd
                 kubernetesCluster: $(k8sCluster)
                 namespace: default
@@ -150,7 +150,7 @@ stages:
               inputs:
                 action: deploy
                 connectionType: azureResourceManager
-                azureSubscriptionConnection: azure-nonprod
+                azureSubscriptionConnection: azure-arm
                 azureResourceGroup: HubNonProd
                 kubernetesCluster: $(k8sCluster)
                 namespace: default


### PR DESCRIPTION
## Summary
PR #50 (merged) introduced the AKS migration but referenced a service connection `azure-nonprod` that doesn't exist in this project, causing pipeline validation to fail:

> Step input azureSubscriptionConnection references service connection azure-nonprod which could not be found.

Fix applied on the main feature branch `fix/OPS-18376-azure-pipelines-private-aks` (commit f79d9f9) and carried into this staging-based branch: point `azureSubscriptionConnection` at `azure-arm` instead, for all three KubernetesManifest@1 deploy tasks (Development/Staging/Production).

## Test plan
- [ ] Trigger pipeline on `staging` branch and confirm pipeline validation passes
- [ ] Confirm `KubernetesManifest@1` deploy task succeeds against `hub-staging`

🤖 Generated with [Claude Code](https://claude.com/claude-code)