### PR TITLE
Migrate superset build/push from Docker Hub to shipmnts.azurecr.io; add first-time imagePullSecrets (staging)

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -16,8 +16,9 @@ pr:
 
 variables:
   imageRepository: 'shipmnts/superset'
+  containerRegistry: 'shipmnts.azurecr.io'
   tag: '$(Build.BuildId)'
-  dockerRegistryServiceConnection: 'dockerhub-service-connection'
+  dockerRegistryServiceConnection: 'f4c49f70-1fb0-43e2-8754-5fd5f6235634'
   k8sNamespace: 'default'
   k8sDeploymentName: 'superset'
   dockerfilePath: '**/Dockerfile'
@@ -55,11 +56,11 @@ stages:
             --builder superset-builder \
             --file Dockerfile \
             --build-arg BRANCH=$(Build.SourceBranchName) \
-            --cache-from type=registry,ref=$(imageRepository):buildcache-$(Build.SourceBranchName) \
-            --cache-to type=registry,ref=$(imageRepository):buildcache-$(Build.SourceBranchName),mode=max \
-            --tag $(imageRepository):latest \
-            --tag $(imageRepository):$(tag) \
-            --tag $(imageRepository):$(Build.SourceBranchName) \
+            --cache-from type=registry,ref=$(containerRegistry)/$(imageRepository):buildcache-$(Build.SourceBranchName) \
+            --cache-to type=registry,ref=$(containerRegistry)/$(imageRepository):buildcache-$(Build.SourceBranchName),mode=max \
+            --tag $(containerRegistry)/$(imageRepository):latest \
+            --tag $(containerRegistry)/$(imageRepository):$(tag) \
+            --tag $(containerRegistry)/$(imageRepository):$(Build.SourceBranchName) \
             --push \
             .
     - upload: deployment
@@ -124,7 +125,7 @@ stages:
                 manifests: |
                   $(Pipeline.Workspace)/deployment/staging/superset-deployment.yaml
                 containers: |
-                  $(imageRepository):$(tag)
+                  $(containerRegistry)/$(imageRepository):$(tag)
 
 - stage: Production
   condition: and(succeeded(), eq(variables['build.SourceBranchName'], 'production'))

--- a/deployment/staging/superset-deployment.yaml
+++ b/deployment/staging/superset-deployment.yaml
@@ -13,6 +13,8 @@ spec:
       labels:
         app: superset
     spec:
+      imagePullSecrets:
+        - name: acr-pull
       containers:
         - name: superset
           image: shipmnts/superset


### PR DESCRIPTION
## Summary
Part of the OVH -> ACR registry migration (superset was on public Docker Hub, not OVH -- different starting point, same destination). Adds a containerRegistry variable, swaps dockerRegistryServiceConnection to the shared ACR connection (f4c49f70-1fb0-43e2-8754-5fd5f6235634), prefixes the registry host onto the buildx build/push and the Staging stage's containers override, and adds imagePullSecrets: acr-pull to the staging deployment manifest for the first time (previously unneeded since Docker Hub was public).

Development/Production stages and manifests are untouched in this PR -- those get the same treatment in the final migration round. superset's own cluster-connection configuration (KubernetesManifest@1, azureResourceManager) is untouched, out of scope for a registry-only migration.

Backfill of the currently-deployed staging tag (shipmnts/superset:staging) into ACR is already done.

## Test plan
- [ ] Pipeline build/push succeeds against shipmnts.azurecr.io
- [ ] Staging deploy succeeds and pod can pull the image via the acr-pull secret