### PR TITLE
Migrate superset build/push from Docker Hub to shipmnts.azurecr.io; add first-time imagePullSecrets

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -16,8 +16,9 @@ pr:
 
 variables:
   imageRepository: 'shipmnts/superset'
+  containerRegistry: 'shipmnts.azurecr.io'
   tag: '$(Build.BuildId)'
-  dockerRegistryServiceConnection: 'dockerhub-service-connection'
+  dockerRegistryServiceConnection: 'f4c49f70-1fb0-43e2-8754-5fd5f6235634'
   k8sNamespace: 'default'
   k8sDeploymentName: 'superset'
   dockerfilePath: '**/Dockerfile'
@@ -47,7 +48,7 @@ stages:
           latest
           $(tag)
           $(Build.SourceBranchName)
-        arguments: '--cache-from $(imageRepository):$(Build.SourceBranchName) --build-arg BUILDKIT_INLINE_CACHE=1 --build-arg BRANCH=$(Build.SourceBranchName)'
+        arguments: '--cache-from $(containerRegistry)/$(imageRepository):$(Build.SourceBranchName) --build-arg BUILDKIT_INLINE_CACHE=1 --build-arg BRANCH=$(Build.SourceBranchName)'
 
     - task: Docker@2
       displayName: push image to container registry 
@@ -82,7 +83,7 @@ stages:
                 manifests: |
                   $(Pipeline.Workspace)/deployment/development/superset-deployment.yaml
                 containers: |
-                  $(imageRepository):$(tag)
+                  $(containerRegistry)/$(imageRepository):$(tag)
 
 - stage: Staging
   condition: and(succeeded(), eq(variables['build.SourceBranchName'], 'staging'))
@@ -106,7 +107,7 @@ stages:
                 manifests: |
                   $(Pipeline.Workspace)/deployment/staging/superset-deployment.yaml
                 containers: |
-                  $(imageRepository):$(tag)
+                  $(containerRegistry)/$(imageRepository):$(tag)
 
 - stage: Production
   condition: and(succeeded(), eq(variables['build.SourceBranchName'], 'production'))
@@ -130,4 +131,4 @@ stages:
                 manifests: |
                   $(Pipeline.Workspace)/deployment/production/superset-deployment.yaml
                 containers: |
-                  $(imageRepository):$(tag)
+                  $(containerRegistry)/$(imageRepository):$(tag)

--- a/deployment/development/superset-deployment.yaml
+++ b/deployment/development/superset-deployment.yaml
@@ -13,6 +13,8 @@ spec:
       labels:
         app: superset
     spec:
+      imagePullSecrets:
+        - name: acr-pull
       containers:
         - name: superset
           image: shipmnts/superset

--- a/deployment/production/superset-deployment.yaml
+++ b/deployment/production/superset-deployment.yaml
@@ -13,6 +13,8 @@ spec:
       labels:
         app: superset
     spec:
+      imagePullSecrets:
+        - name: acr-pull
       containers:
         - name: superset
           image: shipmnts/superset

--- a/deployment/staging/superset-deployment.yaml
+++ b/deployment/staging/superset-deployment.yaml
@@ -13,6 +13,8 @@ spec:
       labels:
         app: superset
     spec:
+      imagePullSecrets:
+        - name: acr-pull
       containers:
         - name: superset
           image: shipmnts/superset


### PR DESCRIPTION
## Summary
Part of the OVH -> ACR registry migration (superset was on public Docker Hub, not OVH -- different starting point, same destination). Adds a containerRegistry variable, swaps dockerRegistryServiceConnection to the shared ACR connection (f4c49f70-1fb0-43e2-8754-5fd5f6235634), prefixes the registry host onto the build/push script and all 3 deploy stages' containers overrides, and adds imagePullSecrets: acr-pull to all 3 deployment manifests for the first time (previously unneeded since Docker Hub was public). This one branch covers development/staging/production so it can be merged/promoted across all 3 environments.

superset's own cluster-connection configuration is untouched, out of scope for a registry-only migration.

Backfill of the currently-deployed staging tag (shipmnts/superset:staging) into ACR is already done.

## Test plan
- [ ] Pipeline build/push succeeds against shipmnts.azurecr.io on each environment branch this gets merged into
- [ ] Deploy succeeds and pod can pull the image via the acr-pull secret