### PR TITLE
Migrate superset build/push from Docker Hub to shipmnts.azurecr.io (staging)

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -16,8 +16,9 @@ pr:
 
 variables:
   imageRepository: 'shipmnts/superset'
+  containerRegistry: 'shipmnts.azurecr.io'
   tag: '$(Build.BuildId)'
-  dockerRegistryServiceConnection: 'dockerhub-service-connection'
+  dockerRegistryServiceConnection: 'f4c49f70-1fb0-43e2-8754-5fd5f6235634'
   k8sNamespace: 'default'
   k8sDeploymentName: 'superset'
   dockerfilePath: '**/Dockerfile'
@@ -55,11 +56,11 @@ stages:
             --builder superset-builder \
             --file Dockerfile \
             --build-arg BRANCH=$(Build.SourceBranchName) \
-            --cache-from type=registry,ref=$(imageRepository):buildcache-$(Build.SourceBranchName) \
-            --cache-to type=registry,ref=$(imageRepository):buildcache-$(Build.SourceBranchName),mode=max \
-            --tag $(imageRepository):latest \
-            --tag $(imageRepository):$(tag) \
-            --tag $(imageRepository):$(Build.SourceBranchName) \
+            --cache-from type=registry,ref=$(containerRegistry)/$(imageRepository):buildcache-$(Build.SourceBranchName) \
+            --cache-to type=registry,ref=$(containerRegistry)/$(imageRepository):buildcache-$(Build.SourceBranchName),mode=max \
+            --tag $(containerRegistry)/$(imageRepository):latest \
+            --tag $(containerRegistry)/$(imageRepository):$(tag) \
+            --tag $(containerRegistry)/$(imageRepository):$(Build.SourceBranchName) \
             --push \
             .
     - upload: deployment
@@ -124,7 +125,7 @@ stages:
                 manifests: |
                   $(Pipeline.Workspace)/deployment/staging/superset-deployment.yaml
                 containers: |
-                  $(imageRepository):$(tag)
+                  $(containerRegistry)/$(imageRepository):$(tag)
 
 - stage: Production
   condition: and(succeeded(), eq(variables['build.SourceBranchName'], 'production'))

--- a/deployment/staging/superset-deployment.yaml
+++ b/deployment/staging/superset-deployment.yaml
@@ -13,6 +13,8 @@ spec:
       labels:
         app: superset
     spec:
+      imagePullSecrets:
+        - name: acr-pull
       containers:
         - name: superset
           image: shipmnts/superset


### PR DESCRIPTION
## Summary
Registry migration for superset, shaped for staging's actual pipeline (buildx + self-hosted pool + KubernetesManifest@1/azureResourceManager), which differs structurally from production's pipeline (Docker@2 + ubuntu-latest + KubernetesManifest@0). Applying the production-based branch's diff (#54) here would revert staging's buildx setup, so this is a separate, staging-shaped equivalent of the same registry change:

- containerRegistry variable added, dockerRegistryServiceConnection swapped to the shared ACR connection (f4c49f70-...)
- registry host prefixed onto the buildx build/cache args and the Staging deploy stage's containers override
- imagePullSecrets: acr-pull added to deployment/staging/superset-deployment.yaml (first time -- Docker Hub was public, ACR isn't)

Cluster-connection config (azureResourceManager/kubernetesCluster) is untouched, out of scope for a registry-only change.

## Test plan
- [ ] Pipeline build/push succeeds against shipmnts.azurecr.io
- [ ] Staging deploy succeeds and pod can pull the image via the acr-pull secret