### PR TITLE
Fix RCA: reapply ACR migration after staging pipeline was restructured/force-pushed

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -40,8 +40,9 @@ pr:
 
 variables:
   imageRepository: "shipmnts/superset"
+  containerRegistry: "shipmnts.azurecr.io"
   tag: "$(Build.BuildId)"
-  dockerRegistryServiceConnection: "dockerhub-service-connection"
+  dockerRegistryServiceConnection: "f4c49f70-1fb0-43e2-8754-5fd5f6235634"
   k8sNamespace: "default"
   k8sDeploymentName: "superset"
   dockerfilePath: "**/Dockerfile"
@@ -82,7 +83,7 @@ stages:
                 latest
                 $(tag)
                 $(Build.SourceBranchName)
-              arguments: "--cache-from $(imageRepository):$(Build.SourceBranchName) --build-arg BUILDKIT_INLINE_CACHE=1 --build-arg BRANCH=$(Build.SourceBranchName)"
+              arguments: "--cache-from $(containerRegistry)/$(imageRepository):$(Build.SourceBranchName) --build-arg BUILDKIT_INLINE_CACHE=1 --build-arg BRANCH=$(Build.SourceBranchName)"
 
           - task: Docker@2
             displayName: push image to container registry

--- a/deployment/development/superset-deployment.yaml
+++ b/deployment/development/superset-deployment.yaml
@@ -13,9 +13,11 @@ spec:
       labels:
         app: superset
     spec:
+      imagePullSecrets:
+        - name: acr-pull
       containers:
         - name: superset
-          image: shipmnts/superset:__tag__
+          image: shipmnts.azurecr.io/shipmnts/superset:__tag__
           ports:
             - containerPort: 8088
           envFrom:

--- a/deployment/production/superset-deployment.yaml
+++ b/deployment/production/superset-deployment.yaml
@@ -13,9 +13,11 @@ spec:
       labels:
         app: superset
     spec:
+      imagePullSecrets:
+        - name: acr-pull
       containers:
         - name: superset
-          image: shipmnts/superset:__tag__
+          image: shipmnts.azurecr.io/shipmnts/superset:__tag__
           ports:
             - containerPort: 8088
           envFrom:

--- a/deployment/staging/superset-deployment.yaml
+++ b/deployment/staging/superset-deployment.yaml
@@ -13,9 +13,11 @@ spec:
       labels:
         app: superset
     spec:
+      imagePullSecrets:
+        - name: acr-pull
       containers:
         - name: superset
-          image: shipmnts/superset:__tag__
+          image: shipmnts.azurecr.io/shipmnts/superset:__tag__
           ports:
             - containerPort: 8088
           envFrom:


### PR DESCRIPTION
## RCA
staging's push step was failing with \`denied: requested access to the resource is denied\`. Root cause: after PR #55 (the original ACR migration) merged, someone else substantially restructured this pipeline (moved to GKE + replacetokens, matching turingbot/mono-operations' pattern) and force-pushed \`staging\` in the process -- which reverted \`dockerRegistryServiceConnection\` back to \`dockerhub-service-connection\` and dropped the ACR fix entirely. The pipeline has been pushing (and failing) against Docker Hub since.

## Fix
Reapplied the registry migration against the new pipeline structure:
- \`containerRegistry\` variable added, \`dockerRegistryServiceConnection\` swapped to the shared ACR connection (f4c49f70-...)
- registry host prefixed onto the build \`--cache-from\` arg
- all 3 environment manifests (development/staging/production -- now unified under one \`deploy-superset-steps.yml\` template) get the ACR host prefix on their image reference, plus \`imagePullSecrets: acr-pull\` for the first time

## Test plan
- [ ] Push step succeeds against shipmnts.azurecr.io
- [ ] Staging deploy pulls the image successfully via the acr-pull secret